### PR TITLE
Bump `read-installed` to 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   ],
   "dependencies": {
-    "read-installed": "3.1.3",
+    "read-installed": "~4.0.3",
     "underscore": "~1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This removes the `graceful-fs` warning from the package.